### PR TITLE
Editorial changes to draft-ietf-netconf-crypto-types.xml

### DIFF
--- a/draft-ietf-netconf-crypto-types.xml
+++ b/draft-ietf-netconf-crypto-types.xml
@@ -258,7 +258,7 @@ Typedefs:
             </ul>
             <t>Each of these groupings are presented in the following subsections.</t>
 
-            <section title="The &quot;encrypted-value-grouping&quot; Grouping" anchor="encrypted-value-grouping">
+            <section title='The "encrypted-value-grouping" Grouping' anchor="encrypted-value-grouping">
               <t>The following tree diagram <xref target="RFC8340"/> illustrates the
                 "encrypted-value-grouping" grouping:</t>
               <t>
@@ -860,7 +860,7 @@ INSERT_TEXT_FROM_FILE(ietf-crypto-types@YYYY-MM-DD.yang)
       </section>
 
       <section title="IANA Considerations">
-        <section title="The &quot;IETF XML&quot; Registry">
+        <section title='The "IETF XML" Registry'>
           <t>This document registers one URI in the "ns" subregistry
           of the "IETF XML" registry <xref target="RFC3688"/>.  Following
           the format in <xref target="RFC3688"/>, the following
@@ -875,7 +875,7 @@ INSERT_TEXT_FROM_FILE(ietf-crypto-types@YYYY-MM-DD.yang)
             </figure>
           </t>
         </section>
-        <section title="The &quot;YANG Module Names&quot; Registry">
+        <section title='The "YANG Module Names" Registry'>
           <t>This document registers one YANG module in the
           "YANG Module Names" registry <xref target="RFC6020"/>.
           Following the format in <xref target="RFC6020"/>, the

--- a/draft-ietf-netconf-crypto-types.xml
+++ b/draft-ietf-netconf-crypto-types.xml
@@ -177,12 +177,14 @@ Identities:
             <!--</aside>-->
             <t>Comments:</t>
             <ul>
-              <li>The diagram shows that there are four base identities.  The
+              <li>The diagram shows that there are five base identities.  The
                 first three identities are used to indicate the format for the
                 key data, while the fourth identity is used to indicate the format
-                for encrypted values.  The base identities are "abstract",
-                in the object oriented programming sense, in that they only
-                define a "class" of formats, rather than a specific format.</li>
+                for encrypted values.  The fifth identity is used to indicate the
+                format for a certificate signing request.  The base identities are
+                "abstract", in the object oriented programming sense, in that
+                they only define a "class" of formats, rather than a specific
+                format.</li>
               <li>The various terminal identities define specific encoding
                 formats.  The derived identities defined in this document are
                 sufficient for the effort described in <xref target="collective-effort"/>
@@ -247,6 +249,7 @@ Typedefs:
               <li>symmetric-key-grouping</li>
               <li>public-key-grouping</li>
               <li>asymmetric-key-pair-grouping</li>
+              <li>certificate-expiration-grouping</li>
               <li>trust-anchor-cert-grouping</li>
               <li>end-entity-cert-grouping</li>
               <li>generate-csr-grouping</li>
@@ -255,7 +258,7 @@ Typedefs:
             </ul>
             <t>Each of these groupings are presented in the following subsections.</t>
 
-            <section title='The "encrypted-value-grouping" Grouping' anchor="encrypted-value-grouping">
+            <section title="The &quot;encrypted-value-grouping&quot; Grouping" anchor="encrypted-value-grouping">
               <t>The following tree diagram <xref target="RFC8340"/> illustrates the
                 "encrypted-value-grouping" grouping:</t>
               <t>
@@ -857,7 +860,7 @@ INSERT_TEXT_FROM_FILE(ietf-crypto-types@YYYY-MM-DD.yang)
       </section>
 
       <section title="IANA Considerations">
-        <section title='The "IETF XML" Registry'>
+        <section title="The &quot;IETF XML&quot; Registry">
           <t>This document registers one URI in the "ns" subregistry
           of the "IETF XML" registry <xref target="RFC3688"/>.  Following
           the format in <xref target="RFC3688"/>, the following
@@ -872,7 +875,7 @@ INSERT_TEXT_FROM_FILE(ietf-crypto-types@YYYY-MM-DD.yang)
             </figure>
           </t>
         </section>
-        <section title='The "YANG Module Names" Registry'>
+        <section title="The &quot;YANG Module Names&quot; Registry">
           <t>This document registers one YANG module in the
           "YANG Module Names" registry <xref target="RFC6020"/>.
           Following the format in <xref target="RFC6020"/>, the


### PR DESCRIPTION
* The "certificate-expiration-grouping" is missing in the list of groupings
* There are five base identities - so, just add a line about the "csr-format" identity.

Other than these, I just changed the double quote character to '&quot;' in a few places, in order to be consistent.